### PR TITLE
Fix for PHP7

### DIFF
--- a/controllers/components/auth_module.php
+++ b/controllers/components/auth_module.php
@@ -10,7 +10,7 @@
  * @author Compass
  * @license LGPL {@link http://www.gnu.org/copyleft/lesser.html}
  */
-class AuthModule extends Object {
+class AuthModule extends CakeObject {
 
     /**
      * hasLoginForm if the authentication module uses build-in login form.


### PR DESCRIPTION
- fix to work with patched Cake 1.3.21 and PHP7

Should probably create a new branch to keep the master branch backward compatible. 